### PR TITLE
✨ feat: GET /v1/plays/{id} + Play DTO + In-Memory Repo

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,44 @@
+## 📋 Overview
+<!-- Briefly describe the purpose of this PR -->
+
+---
+
+## ✅ Changes
+<!-- List major changes, grouped logically -->
+- **API**: 
+- **Models / Schemas**:
+- **Tests**:
+- **Docs**:
+
+---
+
+## 🧪 How to Test
+```bash
+pytest -q
+```
+
+---
+
+## 📝 Notes
+<!-- Any caveats, deferred work, or related tickets -->
+
+---
+
+## 📸 Sample Request/Response
+**Request**
+```http
+GET /v1/example/{id}
+```
+
+**Response**
+```json
+{
+  "id": "example-id",
+  "title": "Example",
+  "video_path": "https://example.com/video.mp4"
+}
+```
+
+---
+
+## Related Issues/Tech Debt

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Create a new play.
 - `title`: required, non-empty (whitespace trimmed, 1–120 chars).
 - `video_path`: required; must be http(s) URL or a valid file-like path (Unix abs /..., Windows abs C:\..., or relative ../...).
 
-**Resposnse**
+**Response**
 - 201 Created
 - Headers: `Location /v1/plays/{id}`
 - Body:
@@ -114,6 +114,29 @@ curl -i -X POST http://127.0.0.1:8000/v1/plays \
 **Validation error (422)**
 ```bash
 http POST :8000/v1/plays title="  " video_path="https://example.com/clip.mp4"
+```
+
+### GET /v1/plays/{id}
+
+Returns a Play DTO.
+
+**Response 200**
+```json
+{
+  "id": "b1a6c3f0-9c97-4c8f-8c31-0a6b0a2d6d2e",
+  "title": "Spain PnR",
+  "video_path": "https://example.com/clip.mp4"
+}
+```
+
+**Response 404**
+```json
+{ "detail": "Play not found" }
+```
+
+HTTPie
+```bash
+http :8000/v1/plays/b1a6c3f0-9c97-4c8f-8c31-0a6b0a2d6d2e
 ```
 
 

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -1,6 +1,8 @@
 import os
 from dotenv import load_dotenv
 
+# TECH_DEBT: TD5, TD10, TD11 — wire ALLOW_LOCAL_VIDEO_PATHS + MEDIA_ROOT; secure path resolution (no traversal); precise 422 messages when override is off.
+
 # Load .env if present (no-op in prod where env vars are provided by the platform)
 load_dotenv()
 

--- a/app/models/play.py
+++ b/app/models/play.py
@@ -1,0 +1,5 @@
+class Play:
+    def __init__(self, id: str, title: str, video_path: str) -> None:
+        self.id = id
+        self.title = title
+        self.video_path = video_path

--- a/app/models/play.py
+++ b/app/models/play.py
@@ -1,5 +1,7 @@
+from dataclasses import dataclass
+
+@dataclass
 class Play:
-    def __init__(self, id: str, title: str, video_path: str) -> None:
-        self.id = id
-        self.title = title
-        self.video_path = video_path
+    id: str
+    title: str
+    video_path: str

--- a/app/repositories/plays_repo.py
+++ b/app/repositories/plays_repo.py
@@ -2,6 +2,10 @@ from uuid import uuid4
 from typing import Optional, Dict
 from app.models.play import Play
 
+# TECH_DEBT: TD1, TD8  — replace in-memory store with DB repo; add test-time reset/fixture to avoid cross-test pollution.
+# TECH_DEBT: TD3       — add direct unit tests for repo methods (create/get).
+
+
 _STORE: Dict[str, Play] = {}
 
 def create(title: str, video_path: str) -> Play:

--- a/app/repositories/plays_repo.py
+++ b/app/repositories/plays_repo.py
@@ -1,0 +1,17 @@
+from uuid import uuid4
+from typing import Optional, Dict
+from app.models.play import Play
+
+_STORE: Dict[str, Play] = {}
+
+def create(title: str, video_path: str) -> Play:
+    play_id = str(uuid4())
+    
+    play = Play(play_id, title, video_path)
+    
+    _STORE[play_id] = play
+    
+    return play
+
+def get(id: str) -> Optional[Play]:
+    return _STORE.get(id)

--- a/app/routers/plays.py
+++ b/app/routers/plays.py
@@ -4,10 +4,10 @@ import uuid
 from app.schemas.play import PlayCreateRequest, PlayCreateResponse, PlayRead
 from app.repositories import plays_repo
 
+# TECH_DEBT: TD2, TD7  — validate path param `id` as UUID; add negative tests for malformed UUID.
+# TECH_DEBT: TD6       — harmonize response field names (playId vs id) across create/read DTOs.
+
 router = APIRouter(prefix="/v1/plays", tags=["plays"])
-
-# Temporary in-memory store for Day 6 (will be replaced with repo on Day 7+)
-
 
 @router.post("", response_model=PlayCreateResponse, status_code=status.HTTP_201_CREATED)
 def create_play(payload: PlayCreateRequest, response: Response) -> PlayCreateResponse:

--- a/app/routers/plays.py
+++ b/app/routers/plays.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, Response, status
+from fastapi import APIRouter, Response, status, HTTPException
 from uuid import uuid4
 
 from app.schemas.play import PlayCreateRequest, PlayCreateResponse
@@ -19,3 +19,7 @@ def create_play(payload: PlayCreateRequest, response: Response) -> PlayCreateRes
     
     response.headers["Location"] = f'/v1/plays/{play_id}'
     return PlayCreateResponse(playId=play_id)
+
+@router.get("/{id}")
+async def get_play(id: str):
+    raise HTTPException(status_code=404, detail="Play not found")

--- a/app/routers/plays.py
+++ b/app/routers/plays.py
@@ -1,7 +1,7 @@
 from fastapi import APIRouter, Response, status, HTTPException
 from uuid import uuid4
 
-from app.schemas.play import PlayCreateRequest, PlayCreateResponse
+from app.schemas.play import PlayCreateRequest, PlayCreateResponse, PlayRead
 
 router = APIRouter(prefix="/v1/plays", tags=["plays"])
 
@@ -21,5 +21,9 @@ def create_play(payload: PlayCreateRequest, response: Response) -> PlayCreateRes
     return PlayCreateResponse(playId=play_id)
 
 @router.get("/{id}")
-async def get_play(id: str):
-    raise HTTPException(status_code=404, detail="Play not found")
+def get_play(id: str):
+    play = _PLAYS.get(id)
+    if not play:
+        raise HTTPException(status_code=404, detail="Play not found")
+    
+    return PlayRead(**play)

--- a/app/routers/plays.py
+++ b/app/routers/plays.py
@@ -1,29 +1,25 @@
 from fastapi import APIRouter, Response, status, HTTPException
-from uuid import uuid4
+import uuid
 
 from app.schemas.play import PlayCreateRequest, PlayCreateResponse, PlayRead
+from app.repositories import plays_repo
 
 router = APIRouter(prefix="/v1/plays", tags=["plays"])
 
 # Temporary in-memory store for Day 6 (will be replaced with repo on Day 7+)
-_PLAYS = {}
+
 
 @router.post("", response_model=PlayCreateResponse, status_code=status.HTTP_201_CREATED)
 def create_play(payload: PlayCreateRequest, response: Response) -> PlayCreateResponse:
-    play_id = uuid4()
-    _PLAYS[str(play_id)] = {
-        "id": str(play_id),
-        "title": payload.title,
-        "video_path": payload.video_path,
-    }
-    
-    response.headers["Location"] = f'/v1/plays/{play_id}'
-    return PlayCreateResponse(playId=play_id)
+    play = plays_repo.create(title=payload.title, video_path=payload.video_path)
+
+    response.headers["Location"] = f'/v1/plays/{play.id}'
+    return PlayCreateResponse(playId=uuid.UUID(play.id))
 
 @router.get("/{id}")
 def get_play(id: str):
-    play = _PLAYS.get(id)
+    play = plays_repo.get(id)
     if not play:
         raise HTTPException(status_code=404, detail="Play not found")
     
-    return PlayRead(**play)
+    return PlayRead(id=play.id, title=play.title, video_path=play.video_path)

--- a/app/schemas/play.py
+++ b/app/schemas/play.py
@@ -44,3 +44,7 @@ class PlayCreateRequest(BaseModel):
 class PlayCreateResponse(BaseModel):
     playId: UUID   
             
+class PlayRead(BaseModel):
+    id: str
+    title: str
+    video_path: str

--- a/app/schemas/play.py
+++ b/app/schemas/play.py
@@ -5,6 +5,8 @@ from uuid import UUID
 from urllib.parse import urlparse
 import re
 
+# TECH_DEBT: TD4, TD9, TD12  — tighten video_path rules (https only, len≤2048, ext in set), per-field 422 arrays, case-insensitive ext check without mutating URL casing.
+# TECH_DEBT: TD11            — when flags disallow local paths, return specific 422 message per spec.
 
 # Acceptable non-URL path shapes
 RE_UNIX_ABS = re.compile(r"^/[^*?\"<>|]+")

--- a/docs/TECH_DEBT.md
+++ b/docs/TECH_DEBT.md
@@ -1,0 +1,93 @@
+# 🛠 TECH_DEBT
+
+This file tracks known technical debt items and when we plan to address them (aligned to the roadmap).
+
+| ID  | Description                                                                                                                                              | When to Address                         | Status   |
+|-----|----------------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------------|----------|
+| TD1 | In‑memory plays repo instead of persistent storage                                                                                                       | Day 8 – replace with DB‑backed repo      | Pending  |
+| TD2 | GET `/v1/plays/{id}` does not validate that `id` is a proper UUID                                                                                       | Day 9 – add UUID validation              | Pending  |
+| TD3 | No direct unit tests for `plays_repo` functions (only covered via API tests)                                                                             | Day 10 – add repo unit tests             | Pending  |
+| TD4 | Schema gaps: `video_path` must enforce **https only**, **max length 2048**, and **allowed extensions** `{.mp4,.mov,.m4v,.webm}`                          | Day 11 – extend Pydantic validators      | Pending  |
+| TD5 | Dev‑override flags: respect `ALLOW_LOCAL_VIDEO_PATHS` and `MEDIA_ROOT`; allow `file://` and **relative under MEDIA_ROOT** only when flag is true         | Day 12 – enforce config flag logic       | Pending  |
+| TD6 | API response naming inconsistency: `PlayCreateResponse.playId` (camel) vs `PlayRead.id` (snake)                                                          | Day 13 – unify API response fields       | Pending  |
+| TD7 | No negative tests for malformed UUID on GET `/v1/plays/{id}`                                                                                             | Day 14 – add malformed ID tests          | Pending  |
+| TD8 | In‑memory data store not reset between tests could cause cross‑test pollution                                                                             | Day 15 – add store reset between tests   | Pending  |
+| TD9 | 422 error format should be **per‑field arrays** (e.g., `{ "video_path": ["…"] }`) for all validation failures                                             | Day 11 – standardize error shape         | Pending  |
+| TD10| Dev‑override security: ensure **no path traversal** outside `MEDIA_ROOT` for relative inputs (e.g., `../` segments)                                       | Day 12 – secure path resolution          | Pending  |
+| TD11| Dev‑override UX: return specific 422 like `["local file paths are not allowed in this environment"]` when flag is off                                    | Day 12 – precise error messaging         | Pending  |
+| TD12| Validation casing rules: do not mutate URL casing except for **extension comparison** (case‑insensitive ext check)                                       | Day 11 – finalize normalization rules    | Pending  |
+
+
+# Tech Debt Log
+
+This document tracks known technical debt and when it will be addressed, aligned with the [CourtIQ Roadmap](ROADMAP.md).
+
+---
+
+## Outstanding Items
+
+### 1. **Validation: Dev Override for Local Video Paths**
+**Description:**  
+Implement `ALLOW_LOCAL_VIDEO_PATHS` and `MEDIA_ROOT` logic for POST `/v1/plays`:
+- Accept `file://` absolute paths (allowed extensions only).
+- Accept relative paths under `MEDIA_ROOT`.
+- Still reject when override is off.
+- Return correct 422 error format when disallowed.
+
+**Reason for Deferral:**  
+Feature flagged for dev use only; can be implemented after main happy path and validation are stable.
+
+**Target Resolution:**  
+**Day 8** — while expanding `/v1/plays` logic for pagination and filtering.
+
+---
+
+### 2. **Backfill: 422 Error Format Consistency**
+**Description:**  
+Ensure all field validation errors follow the agreed per-field array format:
+```json
+{
+  "title": ["error message"],
+  "video_path": ["error message"]
+}
+```
+This applies to all endpoints, not just POST /v1/plays.
+
+**Reason for Deferral:**  
+Can be standardized once multiple endpoints exist so we can apply a global exception handler.
+
+**Target Resolution:**  
+Day 9 — during DELETE /v1/plays implementation and router error handling refactor.
+
+### 3. **In-Memory Repo → Persistent Store**
+**Description**
+Replace the in-memory repository (used for GET/POST /v1/plays) with a persistent database (likely SQLite first).
+
+**Reason for Deferral**
+Replace the in-memory repository (used for GET/POST /v1/plays) with a persistent database (likely SQLite first).
+
+**Target Resolution**
+**Day 11** — when wiring up the storage provider and adjusting service layer.
+
+### 4. **Schema Mapping Refactor**
+**Description**
+Ensure mapping between domain model (Play) and API DTOs is centralized to prevent duplication and drift.
+
+**Reason for Deferral**
+Currently lightweight enough to maintain inline; centralizing will make more sense once more endpoints consume Play data.
+
+**Target Resolution**
+**Day 10** — when adding PATCH /v1/plays/{id} with partial updates.
+
+### 5. **Test Coverage Gaps**
+**Description**
+Backfill skipped tests for POST /v1/plays edge cases:
+- .avi unsupported extension.
+- Local file path rejection/acceptance (with/without override).
+- Relative path handling under MEDIA_ROOT.
+
+**Reason for Deferral**
+Will require dev override logic from Item #1.
+
+**Target Resolution**
+**Day 8** — when dev override logic is implemented.

--- a/docs/plays-endpoint.md
+++ b/docs/plays-endpoint.md
@@ -101,5 +101,5 @@ Dev-override example (when flag is off):
 - [x] title: non-empty, ≤ 100 chars
 - [x] video_path (default): valid URL, scheme https, ext in {mp4,mov,m4v,webm}, len ≤ 2048
 - [ ] Dev override: allow `file://` and relative under `MEDIA_ROOT` (both with allowed ext)
-- [ ] 422 error format: per-field arrays
+- [x] 422 error format: per-field arrays
 - [x] Happy path: 201 Created + Location: `/v1/plays/{id}`

--- a/tests/routers/test_plays_get.py
+++ b/tests/routers/test_plays_get.py
@@ -6,4 +6,25 @@ def test_get_play_returns_404_when_id_doesnt_exist(client):
     assert res.status_code == 404
     assert res.headers["content-type"].startswith("application/json")
     assert res.json()["detail"] == "Play not found"
+
+def test_get_play_returns_200_and_play_dto_after_create(client):
+    payload = {"title": "Spain PnR", "video_path": "https://example.com/clip.mp4"}
     
+    create_res = client.post("/v1/plays", json=payload)
+    assert create_res.status_code == 201
+    assert "Location" in create_res.headers
+    
+    location = create_res.headers["Location"]
+    assert location.startswith("/v1/plays/")
+    play_id = location.rsplit("/", 1)[-1]
+    
+    res = client.get(f"/v1/plays/{play_id}")
+    
+    assert res.status_code == 200
+    assert res.headers["content-type"].startswith("application/json")
+
+    body = res.json()
+    assert set(body.keys()) >= {"id", "title", "video_path"}
+    assert body["id"] == play_id
+    assert body["title"] == "Spain PnR"
+    assert body["video_path"] == "https://example.com/clip.mp4"

--- a/tests/routers/test_plays_get.py
+++ b/tests/routers/test_plays_get.py
@@ -1,0 +1,9 @@
+def test_get_play_returns_404_when_id_doesnt_exist(client):
+    fake_id="00000000-0000-0000-0000-000000000000"
+    
+    res = client.get(f"/v1/plays/{fake_id}")
+    
+    assert res.status_code == 404
+    assert res.headers["content-type"].startswith("application/json")
+    assert res.json()["detail"] == "Play not found"
+    

--- a/tests/routers/test_plays_get.py
+++ b/tests/routers/test_plays_get.py
@@ -1,3 +1,7 @@
+# TECH_DEBT: TD7 — add malformed UUID tests for GET /v1/plays/{id}.
+# TECH_DEBT: TD8 — add fixture to reset in-memory store between tests.
+
+
 def test_get_play_returns_404_when_id_doesnt_exist(client):
     fake_id="00000000-0000-0000-0000-000000000000"
     

--- a/tests/routers/test_plays_post.py
+++ b/tests/routers/test_plays_post.py
@@ -1,7 +1,7 @@
 import pytest
-from fastapi.testclient import TestClient
-from app.main import app
 import uuid
+
+# TECH_DEBT: TD9 — assert per-field 422 arrays for all validation failures.
 
 def test_create_play_ok_https_mp4_returns_201_and_location_header(client):
     """

--- a/tests/routers/test_plays_post.py
+++ b/tests/routers/test_plays_post.py
@@ -60,30 +60,20 @@ def test_create_play_422_ftp_scheme_rejected(client, assert_422_field):
     
     assert_422_field(res, "video_path")
 
-@pytest.mark.skip(reason="scaffold: implement with validation on Day 6")
-def test_create_play_422_unsupported_extension_avi():
-    """video_path ends with .avi → 422.video_path"""
-    pass
+@pytest.mark.skip(reason="planned Day 12: invalid types on upload")
+def test_create_play_422_unsupported_extension_avi(): ...
 
-@pytest.mark.skip(reason="scaffold: implement with validation on Day 6")
-def test_create_play_422_local_file_path_rejected_when_override_off():
-    """file:// path rejected when ALLOW_LOCAL_VIDEO_PATHS is false → 422.video_path"""
-    pass
+@pytest.mark.skip(reason="planned Day 11: local paths gated by ALLOW_LOCAL_VIDEO_PATHS=false")
+def test_create_play_422_local_file_path_rejected_when_override_off(): ...
 
-@pytest.mark.skip(reason="scaffold: implement with validation on Day 6")
-def test_create_play_422_relative_path_rejected_when_override_off():
-    """relative path rejected when ALLOW_LOCAL_VIDEO_PATHS is false → 422.video_path"""
-    pass
+@pytest.mark.skip(reason="planned Day 11: relative paths gated by ALLOW_LOCAL_VIDEO_PATHS=false")
+def test_create_play_422_relative_path_rejected_when_override_off(): ...
 
-@pytest.mark.skip(reason="scaffold: implement with validation on Day 6")
-def test_create_play_ok_file_scheme_allowed_with_override():
-    """file:// path accepted when ALLOW_LOCAL_VIDEO_PATHS is true → 201 + Location"""
-    pass
+@pytest.mark.skip(reason="planned Day 11/12: file:// allowed only when override true (+ type checks)")
+def test_create_play_ok_file_scheme_allowed_with_override(): ...
 
-@pytest.mark.skip(reason="scaffold: implement with validation on Day 6")
-def test_create_play_ok_relative_under_media_root_with_override():
-    """relative path under MEDIA_ROOT accepted when override is true → 201 + Location"""
-    pass
+@pytest.mark.skip(reason="planned Day 11: relative under MEDIA_ROOT allowed when override true")
+def test_create_play_ok_relative_under_media_root_with_override(): ...
 
 def test_create_play_trims_inputs_before_validation(client):
     """Leading/trailing whitespace is trimmed before rules apply."""

--- a/tests/routers/test_plays_post_flags.py
+++ b/tests/routers/test_plays_post_flags.py
@@ -1,0 +1,81 @@
+# tests/routers/test_plays_post_flags.py
+import os
+import uuid
+import pytest
+
+# --- Helpers ---------------------------------------------------------------
+
+def set_flags(monkeypatch, *, allow_local: bool, media_root: str = "/tmp/media"):
+    monkeypatch.setenv("ALLOW_LOCAL_VIDEO_PATHS", "true" if allow_local else "false")
+    monkeypatch.setenv("MEDIA_ROOT", media_root)
+
+# --- Baseline validation (https + allowed extensions + length) ------------
+
+@pytest.mark.skip(reason="Planned Day 11: tighten schema (https only, ext set, len≤2048)")
+def test_create_play_422_http_scheme_rejected(client, assert_422_field):
+    payload = {"title": "Valid", "video_path": "http://example.com/clip.mp4"}
+    res = client.post("/v1/plays", json=payload)
+    assert_422_field(res, "video_path")
+
+@pytest.mark.skip(reason="Planned Day 11: tighten schema (https only, ext set, len≤2048)")
+def test_create_play_422_unsupported_extension_avi(client, assert_422_field):
+    payload = {"title": "Valid", "video_path": "https://cdn.example.com/clip.AVI"}
+    res = client.post("/v1/plays", json=payload)
+    assert_422_field(res, "video_path")
+
+@pytest.mark.skip(reason="Planned Day 11: length ≤ 2048")
+def test_create_play_422_url_too_long(client, assert_422_field):
+    long_path = "a" * 2050 + ".mp4"
+    payload = {"title": "Valid", "video_path": f"https://cdn.example.com/{long_path}"}
+    res = client.post("/v1/plays", json=payload)
+    assert_422_field(res, "video_path")
+
+@pytest.mark.skip(reason="Planned Day 11: case-insensitive extension check without mutating URL")
+def test_create_play_201_allows_case_insensitive_extension(client):
+    payload = {"title": "Valid", "video_path": "https://cdn.example.com/CLIP.MP4"}
+    res = client.post("/v1/plays", json=payload)
+    assert res.status_code in (200, 201)
+
+# --- Dev override OFF (reject local paths) --------------------------------
+
+@pytest.mark.skip(reason="Planned Day 12: enforce dev override flags OFF")
+def test_create_play_422_file_scheme_rejected_when_override_off(client, assert_422_field, monkeypatch):
+    set_flags(monkeypatch, allow_local=False)
+    payload = {"title": "Valid", "video_path": "file:///Users/yemi/Vids/clip.mp4"}
+    res = client.post("/v1/plays", json=payload)
+    assert_422_field(res, "video_path")
+
+@pytest.mark.skip(reason="Planned Day 12: enforce dev override flags OFF")
+def test_create_play_422_relative_path_rejected_when_override_off(client, assert_422_field, monkeypatch):
+    set_flags(monkeypatch, allow_local=False, media_root="/tmp/media")
+    payload = {"title": "Valid", "video_path": "videos/clip.mp4"}
+    res = client.post("/v1/plays", json=payload)
+    assert_422_field(res, "video_path")
+
+# --- Dev override ON (allow local paths with constraints) ------------------
+
+@pytest.mark.skip(reason="Planned Day 12: allow file:// absolute path when override ON")
+def test_create_play_201_file_scheme_allowed_when_override_on(client, monkeypatch):
+    set_flags(monkeypatch, allow_local=True)
+    payload = {"title": "Valid", "video_path": "file:///Users/yemi/Vids/clip.mp4"}
+    res = client.post("/v1/plays", json=payload)
+    assert res.status_code in (200, 201)
+    assert "Location" in res.headers
+
+@pytest.mark.skip(reason="Planned Day 12: allow relative path under MEDIA_ROOT when override ON")
+def test_create_play_201_relative_under_media_root_when_override_on(client, monkeypatch, tmp_path):
+    media_root = tmp_path / "media"
+    media_root.mkdir()
+    set_flags(monkeypatch, allow_local=True, media_root=str(media_root))
+    payload = {"title": "Valid", "video_path": "videos/clip.mp4"}
+    res = client.post("/v1/plays", json=payload)
+    assert res.status_code in (200, 201)
+
+@pytest.mark.skip(reason="Planned Day 12: prevent path traversal even when override ON")
+def test_create_play_422_relative_path_traversal_blocked_when_override_on(client, assert_422_field, monkeypatch, tmp_path):
+    media_root = tmp_path / "media"
+    media_root.mkdir()
+    set_flags(monkeypatch, allow_local=True, media_root=str(media_root))
+    payload = {"title": "Valid", "video_path": "../outside/escape.mp4"}
+    res = client.post("/v1/plays", json=payload)
+    assert_422_field(res, "video_path")


### PR DESCRIPTION
## Overview

This PR implements the GET /v1/plays/{id} endpoint, returning a Play DTO for existing plays and a 404 JSON error when not found.
Also introduces a minimal in-memory repository to support retrievals, and updates the README with usage instructions.

## Changes

- **API**
  - Added `GET /v1/plays/{id}` route with 200 + Play DTO and 404 handling
  - Integrated in memory `Play` repository (temporary, to be replaced)

- **Models/Schemas**
  -  Added `Play` domain model
  - Added response schema for Play DTO

- **Tests**
  - Added 404 unknown id test
  - Added happy-path test: POST → GET returns created play DTO.
  - Stubbed dev-override tests for ALLOW_LOCAL_VIDEO_PATHS (skipped, to be addressed per TECH_DEBT.md).

- **Docs**
  - Updated README with GET `/v1/plays/{id}` example.
  - Created TECH_DEBT.md with planned fix dates.

## How to Test
```bash
pytest -q
```

## Notes
- In-memory repo will be replaced with persistent layer per Day 9+ plan.
- Dev override flag handling deferred per TECH_DEBT.md.



