### PR TITLE
GET /v1/plays with cursor pagination + title prefix filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,58 @@ HTTPie
 http :8000/v1/plays/b1a6c3f0-9c97-4c8f-8c31-0a6b0a2d6d2e
 ```
 
+## GET `/v1/plays` — List Plays (cursor pagination + title prefix filter)
+
+### Query Params
+- `limit` *(int, 1–100, default 10)* — max items per page.
+- `cursor` *(string, optional)* — the **last returned `id`** from the previous page. Results start **after** this id within the filtered view.
+- `title` *(string, optional)* — case-insensitive, trimmed **prefix** filter applied to `title`. Filtering happens **before** pagination.
+
+### Response
+```json
+{
+  "data": [
+    { "id": "f7b3…", "title": "Alpha Cut", "video_path": "https://…" }
+  ],
+  "nextCursor": "3c9e…"  // null when no more results
+}
+```
+
+### Examples
+**First Page**
+```bash
+curl -s 'http://localhost:8000/v1/plays?limit=2'
+```
+→
+```json
+{
+  "data": [
+    {"id":"…","title":"Alpha Cut","video_path":"…"},
+    {"id":"…","title":"Alpha Spain","video_path":"…"}
+  ],
+  "nextCursor":"<id-of-Alpha-Spain>"
+}
+
+```
+
+**Next Page**
+```bash
+curl -s 'http://localhost:8000/v1/plays?limit=2&cursor=<id-of-Alpha-Spain>'
+```
+
+**Filter by title prefix (case-insensitive)**
+```bash
+curl -s 'http://localhost:8000/v1/plays?limit=10&title=  alpha  '
+```
+
+**Invalid Cursor**
+```bash
+curl -i 'http://localhost:8000/v1/plays?cursor=bogus'
+# HTTP/1.1 400 Bad Request
+# {"detail":"Invalid cursor"}
+```
+
+
 
 
 ## Contributing

--- a/app/repositories/plays_repo.py
+++ b/app/repositories/plays_repo.py
@@ -1,5 +1,5 @@
 from uuid import uuid4
-from typing import Optional, Dict
+from typing import Optional, Dict, List, Tuple
 from app.models.play import Play
 
 # TECH_DEBT: TD1, TD8  — replace in-memory store with DB repo; add test-time reset/fixture to avoid cross-test pollution.
@@ -7,6 +7,11 @@ from app.models.play import Play
 
 
 _STORE: Dict[str, Play] = {}
+
+def _matches_prefix(title: str, prefix: Optional[str]) -> bool:
+    if not prefix:                 # None or ""
+        return True
+    return title.casefold().startswith(prefix.strip().casefold())
 
 def create(title: str, video_path: str) -> Play:
     play_id = str(uuid4())
@@ -19,3 +24,38 @@ def create(title: str, video_path: str) -> Play:
 
 def get(id: str) -> Optional[Play]:
     return _STORE.get(id)
+
+def clear_store():
+    _STORE.clear()
+
+
+def list_plays(cursor: Optional[str], limit: int, title_prefix: Optional[str] = None) -> Tuple[List[Play], Optional[str]]:
+    # 1) Keys are in insertion order in Python 3.7+
+    keys = [k for k in _STORE if _matches_prefix(_STORE[k].title, title_prefix)]
+    
+    # Normalize limit
+    lim = max(0, int(limit))
+    
+    # 2) Find start index strictly after the cursor
+    if cursor is None:
+        start_idx = 0
+    else:
+        try:
+            start_idx = keys.index(cursor) + 1
+        except ValueError:
+            # TODO: - choose a policy
+            # (a) treat as empty page, or
+            # (b) treat as beginning (start_idx = 0), or
+            # (c) raise 400 in the router layer.
+            start_idx = 0 # for now
+    
+    # 3) Slice the page
+    end_idx = start_idx + lim
+    page_keys = keys[start_idx:end_idx]
+    items = [ _STORE[k] for k in page_keys ]        
+    
+    # 4) Compute next cursor
+    has_more = end_idx < len(keys)
+    next_cursor = page_keys[-1] if (page_keys and has_more) else None
+    
+    return items, next_cursor

--- a/app/repositories/plays_repo.py
+++ b/app/repositories/plays_repo.py
@@ -9,6 +9,7 @@ from app.models.play import Play
 _STORE: Dict[str, Play] = {}
 
 def _matches_prefix(title: str, prefix: Optional[str]) -> bool:
+    """Case-insensitive, trimmed prefix match. None/'' => match all."""
     if not prefix:                 # None or ""
         return True
     return title.casefold().startswith(prefix.strip().casefold())
@@ -30,6 +31,13 @@ def clear_store():
 
 
 def list_plays(cursor: Optional[str], limit: int, title_prefix: Optional[str] = None) -> Tuple[List[Play], Optional[str]]:
+    """Filter by title prefix, then paginate over stable insertion order.
+
+    Cursor policy:
+    - cursor must be an id present within the filtered view; otherwise ValueError('invalid_cursor')
+    - results start strictly AFTER the cursor
+    - next_cursor is the last id in the page iff more items remain
+    """
     # 1) Keys are in insertion order in Python 3.7+
     keys = [k for k in _STORE if _matches_prefix(_STORE[k].title, title_prefix)]
     

--- a/app/repositories/plays_repo.py
+++ b/app/repositories/plays_repo.py
@@ -43,11 +43,7 @@ def list_plays(cursor: Optional[str], limit: int, title_prefix: Optional[str] = 
         try:
             start_idx = keys.index(cursor) + 1
         except ValueError:
-            # TODO: - choose a policy
-            # (a) treat as empty page, or
-            # (b) treat as beginning (start_idx = 0), or
-            # (c) raise 400 in the router layer.
-            start_idx = 0 # for now
+            raise ValueError("invalid_cursor")
     
     # 3) Slice the page
     end_idx = start_idx + lim

--- a/app/routers/plays.py
+++ b/app/routers/plays.py
@@ -4,6 +4,7 @@ from typing import Optional, List
 
 from app.schemas.play import PlayCreateRequest, PlayCreateResponse, PlayRead
 from app.repositories import plays_repo
+from app.utils.mappers import to_play_dto
 
 # TECH_DEBT: TD2, TD7  — validate path param `id` as UUID; add negative tests for malformed UUID.
 # TECH_DEBT: TD6       — harmonize response field names (playId vs id) across create/read DTOs.
@@ -32,6 +33,6 @@ def list_plays(limit: int = Query(10, ge=1, le=100), cursor: Optional[str] = Non
     except ValueError:
         raise HTTPException(status_code=400, detail="Invalid cursor")
     
-    dtos: List[PlayRead] = [PlayRead(id=p.id, title=p.title, video_path=p.video_path) for p in items]
+    dtos: List[PlayRead] = [to_play_dto(p) for p in items]
     
     return {"data": dtos, "nextCursor": next_cursor}

--- a/app/routers/plays.py
+++ b/app/routers/plays.py
@@ -11,7 +11,7 @@ from app.utils.mappers import to_play_dto
 
 router = APIRouter(prefix="/v1/plays", tags=["plays"])
 
-@router.post("", response_model=PlayCreateResponse, status_code=status.HTTP_201_CREATED)
+@router.post("/", response_model=PlayCreateResponse, status_code=status.HTTP_201_CREATED)
 def create_play(payload: PlayCreateRequest, response: Response) -> PlayCreateResponse:
     play = plays_repo.create(title=payload.title, video_path=payload.video_path)
 
@@ -26,7 +26,7 @@ def get_play(id: str):
     
     return PlayRead(id=play.id, title=play.title, video_path=play.video_path)
 
-@router.get("")
+@router.get("/")
 def list_plays(limit: int = Query(10, ge=1, le=100), cursor: Optional[str] = None, title: Optional [str] = None):
     try:
         items, next_cursor = plays_repo.list_plays(cursor=cursor, limit=limit, title_prefix=title)

--- a/app/routers/plays.py
+++ b/app/routers/plays.py
@@ -27,7 +27,11 @@ def get_play(id: str):
     return PlayRead(id=play.id, title=play.title, video_path=play.video_path)
 
 @router.get("/")
-def list_plays(limit: int = Query(10, ge=1, le=100), cursor: Optional[str] = None, title: Optional [str] = None):
+def list_plays(
+    limit: int = Query(10, ge=1, le=100),
+    cursor: Optional[str] = None, 
+    title: Optional[str] = None
+):
     try:
         items, next_cursor = plays_repo.list_plays(cursor=cursor, limit=limit, title_prefix=title)
     except ValueError:

--- a/app/routers/plays.py
+++ b/app/routers/plays.py
@@ -1,5 +1,6 @@
-from fastapi import APIRouter, Response, status, HTTPException
+from fastapi import APIRouter, Response, status, HTTPException, Query
 import uuid
+from typing import Optional, List
 
 from app.schemas.play import PlayCreateRequest, PlayCreateResponse, PlayRead
 from app.repositories import plays_repo
@@ -23,3 +24,11 @@ def get_play(id: str):
         raise HTTPException(status_code=404, detail="Play not found")
     
     return PlayRead(id=play.id, title=play.title, video_path=play.video_path)
+
+@router.get("")
+def list_plays(limit: int = Query(10, ge=1, le=100), cursor: Optional[str] = None, title: Optional [str] = None):
+    items, next_cursor = plays_repo.list_plays(cursor=cursor, limit=limit, title_prefix=title)
+    
+    dtos: List[PlayRead] = [PlayRead(id=p.id, title=p.title, video_path=p.video_path) for p in items]
+    
+    return {"data": dtos, "nextCursor": next_cursor}

--- a/app/routers/plays.py
+++ b/app/routers/plays.py
@@ -27,7 +27,10 @@ def get_play(id: str):
 
 @router.get("")
 def list_plays(limit: int = Query(10, ge=1, le=100), cursor: Optional[str] = None, title: Optional [str] = None):
-    items, next_cursor = plays_repo.list_plays(cursor=cursor, limit=limit, title_prefix=title)
+    try:
+        items, next_cursor = plays_repo.list_plays(cursor=cursor, limit=limit, title_prefix=title)
+    except ValueError:
+        raise HTTPException(status_code=400, detail="Invalid cursor")
     
     dtos: List[PlayRead] = [PlayRead(id=p.id, title=p.title, video_path=p.video_path) for p in items]
     

--- a/app/utils/mappers.py
+++ b/app/utils/mappers.py
@@ -1,0 +1,5 @@
+from app.schemas.play import PlayRead
+from app.models.play import Play
+
+def to_play_dto(p: Play) -> PlayRead:
+    return PlayRead(id=p.id, title=p.title, video_path=p.video_path) 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,12 +1,13 @@
 import pytest
 from fastapi.testclient import TestClient
 from app.main import app
+from app.repositories.plays_repo import clear_store
+from typing import Callable, List, Dict, Optional
 
 @pytest.fixture(scope="function")
 def client():
     # fresh client per test to avoid leaking in-memory state across tests
     return TestClient(app)
-
 
 @pytest.fixture
 def assert_422_field():
@@ -23,3 +24,39 @@ def assert_422_field():
             for err in data["detail"]
         )
     return _assert
+
+@pytest.fixture(autouse=True)
+def _reset_repo_state():
+    clear_store()
+
+@pytest.fixture(scope="function")
+def seed_many_plays(client) -> Callable[[List[Dict]], List[Dict]]:
+    """
+    Returns a function that accepts a list of play stubs and seeds them via POST /v1/plays.
+    Each stub should at least include {'title': '...'}.
+    Returns the list of created Play DTOs (in the same order).
+    """
+    def _seed(stubs: List[Dict]) -> List[Dict]:
+        created: List[Dict] = []
+        for i, stub in enumerate(stubs, start=1):
+            # Minimal valid payload 
+            payload = {
+                "title": stub["title"],
+                "video_path": stub.get("video_path", f"https://example.com/clip{i}.mp4")
+            }
+            
+            # POST to create
+            res = client.post("/v1/plays", json=payload)
+            assert res.status_code == 201, res.text
+             
+            location = res.headers.get("Location")
+            assert location and location.startswith("/v1/plays/"), f"Missing Location header: {res.headers}"
+
+            # fetch the created resource to get a DTO with 'id'
+            show = client.get(location)
+            assert show.status_code == 200, show.text
+            created.append(show.json())
+            
+        return created
+    
+    return _seed

--- a/tests/routers/test_plays_list.py
+++ b/tests/routers/test_plays_list.py
@@ -33,3 +33,46 @@ def test_list_plays_pagination_happy_path(client, seed_many_plays):
     assert r3.status_code == 200
     assert [p["title"] for p in b3["data"]] == ["Delta Split"]
     assert b3.get("nextCursor") in (None, )
+    
+def test_list_plays_title_prefix_filter_happy_path(client, seed_many_plays):
+    _ = seed_many_plays([
+        {"title": "Alpha Cut"},
+        {"title": "Alpha Spain"},
+        {"title": "Bravo Ghost"},
+        {"title": "Charlie Spain"},
+        {"title": "Delta Split"},
+    ])
+
+    # case-insensitive + trimmed prefix
+    r = client.get("/v1/plays", params={"limit": 10, "title": "  alpha  "})
+    b = r.json()
+
+    assert r.status_code == 200
+    assert [p["title"] for p in b["data"]] == ["Alpha Cut", "Alpha Spain"]
+    # exactly two results → no more pages
+    assert b.get("nextCursor") in (None,)
+
+def test_list_plays_title_prefix_filter_with_pagination(client, seed_many_plays):
+    created = seed_many_plays([
+        {"title": "Alpha Cut"},
+        {"title": "Alpha Spain"},
+        {"title": "Bravo Ghost"},
+        {"title": "Charlie Spain"},
+        {"title": "Delta Split"},
+    ])
+
+    # Page 1: only Alphas, limit 1
+    r1 = client.get("/v1/plays", params={"limit": 1, "title": "Alpha"})
+    b1 = r1.json()
+    assert r1.status_code == 200
+    assert [p["title"] for p in b1["data"]] == ["Alpha Cut"]
+    # nextCursor should be the id of "Alpha Cut"
+    assert b1["nextCursor"] == created[0]["id"]
+
+    # Page 2: continue within same filter
+    r2 = client.get("/v1/plays", params={"limit": 1, "title": "Alpha", "cursor": b1["nextCursor"]})
+    b2 = r2.json()
+    assert r2.status_code == 200
+    assert [p["title"] for p in b2["data"]] == ["Alpha Spain"]
+    # no more "Alpha..." items
+    assert b2.get("nextCursor") in (None,)

--- a/tests/routers/test_plays_list.py
+++ b/tests/routers/test_plays_list.py
@@ -1,0 +1,35 @@
+
+def test_list_plays_pagination_happy_path(client, seed_many_plays):
+    # Arrange
+    created = seed_many_plays([
+        {"title": "Alpha Cut"},
+        {"title": "Alpha Spain"},
+        {"title": "Bravo Ghost"},
+        {"title": "Charlie Spain"},
+        {"title": "Delta Split"},
+    ])
+    
+    # Page 1
+    r1 = client.get("/v1/plays", params={"limit": 2})
+    b1 = r1.json()
+    
+    assert r1.status_code == 200
+    assert [p["title"] for p in b1["data"]] == ["Alpha Cut", "Alpha Spain"]
+    assert b1["nextCursor"] == created[1]["id"]
+    
+    # Page 2
+    r2 = client.get("/v1/plays", params={"limit": 2, "cursor": b1["nextCursor"]})
+    b2 = r2.json()
+    
+    assert r2.status_code == 200
+    assert [p["title"] for p in b2["data"]] == ["Bravo Ghost", "Charlie Spain"]
+    assert b2["nextCursor"] == created[3]["id"]
+    
+    
+    # Page 3
+    r3 = client.get("/v1/plays", params={"limit": 2, "cursor": b2["nextCursor"]})
+    b3 = r3.json()
+    
+    assert r3.status_code == 200
+    assert [p["title"] for p in b3["data"]] == ["Delta Split"]
+    assert b3.get("nextCursor") in (None, )


### PR DESCRIPTION
Title: Day 8 — GET /v1/plays with cursor pagination + title prefix filter
What’s included
GET /v1/plays route with limit, cursor, title (prefix) parameters.
Repo method list_plays(cursor, limit, title_prefix) implementing filter-then-paginate over insertion order (stable).
Error policy: 400 Invalid cursor when the cursor isn’t in the current filtered view.
Tests:
Pagination happy path (3 pages).
Title filter happy path + paginated within filter.
Edge cases: empty results, cursor at end, bad cursor (400).
README docs & examples.
Notes / Trade-offs
In-memory store with UUID ids; order uses dict insertion order (stable in Py ≥3.7). DB-backed repo planned.
Cursor is plain id; will consider composite/opaque tokens after DB migration.
Follow-ups (TECH_DEBT)
Repo interface + DI for per-test repos.
Migrate to SQLite; consider cursor = (created_at,id) or opaque token.
Add sorting options when DB arrives.
