### PR TITLE
✨ feat: API Validation & List Polishing

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,11 @@ Create a new play.
 ```
 **Validation**
 - `title`: required, non-empty (whitespace trimmed, 1–120 chars).
-- `video_path`: required; must be http(s) URL or a valid file-like path (Unix abs /..., Windows abs C:\..., or relative ../...).
+- `video_path`: required; 
+  - must be http(s) URL or a valid file-like path (Unix abs /..., Windows abs C:\..., or relative ../...)
+  - Max length: 2048
+  - extensions allowed: mp4, mov, m4v, webm
+
 
 **Response**
 - 201 Created
@@ -127,7 +131,7 @@ curl -i -X POST http://127.0.0.1:8000/v1/plays \
 http POST :8000/v1/plays title="  " video_path="https://example.com/clip.mp4"
 ```
 
-### GET /v1/plays/{id}
+### GET `/v1/plays/{id}`
 
 Returns a Play DTO.
 
@@ -165,7 +169,8 @@ http :8000/v1/plays/b1a6c3f0-9c97-4c8f-8c31-0a6b0a2d6d2e
   "data": [
     { "id": "f7b3…", "title": "Alpha Cut", "video_path": "https://…" }
   ],
-  "nextCursor": "3c9e…"  // null when no more results
+  "nextCursor": "3c9e…",  // null when no more results
+  "hasMore": true 
 }
 ```
 
@@ -181,7 +186,8 @@ curl -s 'http://localhost:8000/v1/plays?limit=2'
     {"id":"…","title":"Alpha Cut","video_path":"…"},
     {"id":"…","title":"Alpha Spain","video_path":"…"}
   ],
-  "nextCursor":"<id-of-Alpha-Spain>"
+  "nextCursor":"<id-of-Alpha-Spain>",
+  "hasMore": false
 }
 
 ```

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -83,10 +83,10 @@ _Each item is a suggested commit. Keep using the branch naming convention per da
 ## Day 10 – Validation polish + list clamps
 **Objective:** Validation polish + list clamps
 
-- [ ] ✨ feat(api): harden `video_path` validation (https-only; length ≤ 2048; extensions {.mp4,.mov,.m4v,.webm})
-- [ ] ✅ test(api): list default limit = 10; clamp to [1,100]
-- [ ] 🔨 refactor(api): optional `hasMore` boolean in list response
-- [ ] 📝 docs: update README examples and error shapes
+- [x] ✨ feat(api): harden `video_path` validation (https-only; length ≤ 2048; extensions {.mp4,.mov,.m4v,.webm})
+- [x] ✅ test(api): list default limit = 10; clamp to [1,100]
+- [x] 🔨 refactor(api): optional `hasMore` boolean in list response
+- [x] 📝 docs: update README examples and error shapes
 
 ## Day 11 – Storage Provider Wiring
 

--- a/TECH_DEBT.md
+++ b/TECH_DEBT.md
@@ -7,7 +7,7 @@ This file tracks known technical debt and when we plan to address it (aligned to
 |------|--------------------------------------------------------------------------------------------------------------------------------------------------------|-----------------|-----------|
 | TD1  | In-memory plays repo instead of persistent storage (SQLite first)                                                                                      | Day 11          | Pending   |
 | TD2  | GET `/v1/plays/{id}` lacks strict UUID validation                                                                                                      | Day 9           | Resolved ✅   |
-| TD3  | No direct unit tests for `plays_repo` (currently covered only via API tests)                                                                           | Day 10          | Pending   |
+| TD3  | No direct unit tests for `plays_repo` (currently covered only via API tests)                                                                           | Day 10          | Resolved ✅   |
 | TD4  | `video_path` validation gaps: **https only**, **max length 2048**, allowed extensions `{.mp4,.mov,.m4v,.webm}`                                         | Day 11          | Pending   |
 | TD5  | Dev-override flags: `ALLOW_LOCAL_VIDEO_PATHS` / `MEDIA_ROOT` (allow `file://` + relative under `MEDIA_ROOT` only when flag is true)                    | Day 12          | Pending   |
 | TD6  | API field naming inconsistency: `PlayCreateResponse.playId` (camel) vs `PlayRead.id` (snake)                                                            | Day 13          | Pending   |
@@ -17,12 +17,12 @@ This file tracks known technical debt and when we plan to address it (aligned to
 | TD10 | Dev-override security: prevent path traversal outside `MEDIA_ROOT` (e.g., `../`)                                                                       | Day 12          | Pending   |
 | TD11 | Dev-override UX: precise 422 message like `["local file paths are not allowed in this environment"]` when flag is off                                  | Day 12          | Pending   |
 | TD12 | Normalization rules: don’t mutate URL casing except case-insensitive extension checks                                                                  | Day 11          | Pending   |
-| TD13 | Introduce `PlayRepository` interface + FastAPI dependency override so tests can use a fresh per-test repo instance                                     | Day 10          | Pending   |
+| TD13 | Introduce `PlayRepository` interface + FastAPI dependency override so tests can use a fresh per-test repo instance                                     | Day 10          | Resolved ✅   |
 | TD14 | Cursor design: move from plain `id` to composite/opaque token (e.g., `created_at|id`) after DB migration                                               | Day 12          | Pending   |
-| TD15 | List polish: add `hasMore` boolean (or compute deterministically) alongside `nextCursor`                                                               | Day 9           | Pending   |
+| TD15 | List polish: add `hasMore` boolean (or compute deterministically) alongside `nextCursor`                                                               | Day 9           | Resolved ✅   |
 | TD16 | Normalize collection route paths (avoid trailing-slash 405s)                                                                                           | Day 8           | ✅ Resolved |
 | TD17 | Centralize Play → DTO mapping to avoid drift                                                                                                           | Day 8           | ✅ Resolved |
-| TD18 | Add default‐limit + clamp tests for list (`limit` default 10, clamp to 100)                                                                            | Day 9           | Pending   |
+| TD18 | Add default‐limit + clamp tests for list (`limit` default 10, clamp to 100)                                                                            | Day 9           | Resolved ✅   |
 | TD19 | Standardize UUID usage across all endpoints (create, read, delete) for consistency                                                                     | Day 15          | Pending   |
 | TD20 | Plan for introducing threading lock or concurrency-safe patterns before DB migration                                                                  | Day 14          | Pending   |
 | TD21 | Transactional delete pipeline: cascade deletes (e.g., diagrams, storage blobs, worker jobs)                                         | Day 16                  | Pending   |

--- a/app/deps.py
+++ b/app/deps.py
@@ -1,0 +1,15 @@
+# app/deps.py
+
+from functools import lru_cache
+from app.repositories.plays_repo import PlaysRepository, _assert_protocol
+from app.repositories.memory import MemoryRepository
+
+# singleton factory (cached) to keep state across requests when desired
+@lru_cache(maxsize=1)
+def _singleton_repo() -> PlaysRepository:
+    repo = MemoryRepository()
+    _assert_protocol(repo, PlaysRepository)
+    return repo
+
+def get_repo() -> PlaysRepository:
+    return _singleton_repo()

--- a/app/repositories/memory.py
+++ b/app/repositories/memory.py
@@ -1,0 +1,74 @@
+from uuid import uuid4, UUID
+from typing import Optional, Dict, List, Tuple
+from app.models.play import Play
+
+# TECH_DEBT: TD1, TD8  — replace in-memory store with DB repo; add test-time reset/fixture to avoid cross-test pollution.
+# TECH_DEBT: TD3       — add direct unit tests for repo methods (create/get).
+class MemoryRepository:
+    _STORE: Dict[str, Play]
+    
+    def __init__(self):
+        self._STORE = {}
+
+    def _matches_prefix(self, title: str, prefix: Optional[str]) -> bool:
+        """Case-insensitive, trimmed prefix match. None/'' => match all."""
+        if not prefix:                 # None or ""
+            return True
+        return title.casefold().startswith(prefix.strip().casefold())
+
+    def clear_store(self):
+        self._STORE.clear()
+
+    def create_play(self, title: str, video_path: str) -> Play:
+        play_id = str(uuid4())
+        play = Play(play_id, title, video_path)
+    
+        self._STORE[play_id] = play
+    
+        return play
+    
+    def get_play(self, id: str) -> Optional[Play]:
+        return self._STORE.get(id)
+
+    def list_plays(self, *, cursor: Optional[str] = None, limit: int = 10, title_prefix: Optional[str] = None) -> Tuple[List[Play], Optional[str]]:
+        """Filter by title prefix, then paginate over stable insertion order.
+
+        Cursor policy:
+        - cursor must be an id present within the filtered view; otherwise ValueError('invalid_cursor')
+        - results start strictly AFTER the cursor
+        - next_cursor is the last id in the page iff more items remain
+        """
+        # 1) Keys are in insertion order in Python 3.7+
+        keys = [k for k in self._STORE if self._matches_prefix(self._STORE[k].title, title_prefix)]
+    
+        # Normalize limit
+        lim = max(0, int(limit))
+    
+        # 2) Find start index strictly after the cursor
+        if cursor is None:
+            start_idx = 0
+        else:
+            try:
+                start_idx = keys.index(cursor) + 1
+            except ValueError:
+                raise ValueError("invalid_cursor")
+    
+        # 3) Slice the page
+        end_idx = start_idx + lim
+        page_keys = keys[start_idx:end_idx]
+        items = [ self._STORE[k] for k in page_keys ]        
+    
+        # 4) Compute next cursor
+        has_more = end_idx < len(keys)
+        next_cursor = page_keys[-1] if (page_keys and has_more) else None
+    
+        return items, next_cursor
+
+    def delete_play(self, id: str) -> bool:
+        removed = self._STORE.pop(id, None)
+    
+        return removed is not None
+
+    def clear(self) -> None:
+        self._STORE.clear()
+        

--- a/app/repositories/plays_repo.py
+++ b/app/repositories/plays_repo.py
@@ -1,69 +1,34 @@
-from uuid import uuid4, UUID
-from typing import Optional, Dict, List, Tuple
+from typing import Protocol, Optional, Tuple, List, runtime_checkable
 from app.models.play import Play
 
-# TECH_DEBT: TD1, TD8  — replace in-memory store with DB repo; add test-time reset/fixture to avoid cross-test pollution.
-# TECH_DEBT: TD3       — add direct unit tests for repo methods (create/get).
-
-
-_STORE: Dict[str, Play] = {}
-
-def _matches_prefix(title: str, prefix: Optional[str]) -> bool:
-    """Case-insensitive, trimmed prefix match. None/'' => match all."""
-    if not prefix:                 # None or ""
-        return True
-    return title.casefold().startswith(prefix.strip().casefold())
-
-def clear_store():
-    _STORE.clear()
-
-def create_play(title: str, video_path: str) -> Play:
-    play_id = str(uuid4())
-    
-    play = Play(play_id, title, video_path)
-    
-    _STORE[play_id] = play
-    
-    return play
-
-def get_play(id: str) -> Optional[Play]:
-    return _STORE.get(id)
-
-def list_plays(cursor: Optional[str], limit: int, title_prefix: Optional[str] = None) -> Tuple[List[Play], Optional[str]]:
-    """Filter by title prefix, then paginate over stable insertion order.
-
-    Cursor policy:
-    - cursor must be an id present within the filtered view; otherwise ValueError('invalid_cursor')
-    - results start strictly AFTER the cursor
-    - next_cursor is the last id in the page iff more items remain
+def _assert_protocol(obj: object, proto: type) -> None:
     """
-    # 1) Keys are in insertion order in Python 3.7+
-    keys = [k for k in _STORE if _matches_prefix(_STORE[k].title, title_prefix)]
-    
-    # Normalize limit
-    lim = max(0, int(limit))
-    
-    # 2) Find start index strictly after the cursor
-    if cursor is None:
-        start_idx = 0
-    else:
-        try:
-            start_idx = keys.index(cursor) + 1
-        except ValueError:
-            raise ValueError("invalid_cursor")
-    
-    # 3) Slice the page
-    end_idx = start_idx + lim
-    page_keys = keys[start_idx:end_idx]
-    items = [ _STORE[k] for k in page_keys ]        
-    
-    # 4) Compute next cursor
-    has_more = end_idx < len(keys)
-    next_cursor = page_keys[-1] if (page_keys and has_more) else None
-    
-    return items, next_cursor
+    Assert that an object or class conforms to a Protocol at runtime.
 
-def delete_play(id: str) -> bool:
-    removed = _STORE.pop(id, None)
+    Args:
+        obj: The object or class to check.
+        proto: The Protocol to enforce.
+    Raises:
+        AssertionError: If obj does not implement the Protocol.
+    """
+    if not isinstance(obj, proto):
+        raise AssertionError(
+            f"{obj.__class__.__name__} does not conform to {proto.__name__}"
+        )
+
+@runtime_checkable
+class PlaysRepository(Protocol):
+    # create and return a play
+    def create_play(self, title: str, video_path: str) -> Play: ...
     
-    return removed is not None
+    # get a play by id or None
+    def get_play(self, id: str) -> Optional[Play]: ...
+
+    # list plays with optional cursor, limit, and title prefix filter
+    def list_plays(self, *, cursor: Optional[str] = None, limit: int = 10, title_prefix: Optional[str] = None) -> Tuple[List[Play], Optional[str]]: ...
+    
+    # delete by id, true if something was deleted
+    def delete_play(self, id: str) -> bool: ...
+    
+    # test convenience; clear in-memory state
+    def clear(self) -> None: ...

--- a/app/routers/plays.py
+++ b/app/routers/plays.py
@@ -46,8 +46,9 @@ def list_plays(
         raise HTTPException(status_code=400, detail="Invalid cursor")
     
     dtos: List[PlayRead] = [to_play_dto(p) for p in items]
+    hasMore = next_cursor is not None
     
-    return {"data": dtos, "nextCursor": next_cursor}
+    return {"data": dtos, "nextCursor": next_cursor, "hasMore": hasMore}
 
 @router.delete("/{id}")
 def delete_play(id: str):

--- a/app/routers/plays.py
+++ b/app/routers/plays.py
@@ -28,10 +28,18 @@ def get_play(id: str):
 
 @router.get("/")
 def list_plays(
-    limit: int = Query(10, ge=1, le=100),
+    limit: Optional[int] = Query(None),
     cursor: Optional[str] = None, 
     title: Optional[str] = None
 ):
+    
+    if limit is None:
+        limit = 10
+    elif limit < 1:
+        limit = 1
+    elif limit > 100:
+        limit = 100
+        
     try:
         items, next_cursor = plays_repo.list_plays(cursor=cursor, limit=limit, title_prefix=title)
     except ValueError:

--- a/app/routers/plays.py
+++ b/app/routers/plays.py
@@ -1,10 +1,11 @@
-from fastapi import APIRouter, Response, status, HTTPException, Query
+from fastapi import APIRouter, Response, status, HTTPException, Query, Depends
 import uuid
 from typing import Optional, List
 
 from app.schemas.play import PlayCreateRequest, PlayCreateResponse, PlayRead
-from app.repositories import plays_repo
 from app.utils.mappers import to_play_dto
+from app.deps import get_repo, _singleton_repo
+from app.repositories.plays_repo import PlaysRepository
 
 # TECH_DEBT: TD2, TD7  — validate path param `id` as UUID; add negative tests for malformed UUID.
 # TECH_DEBT: TD6       — harmonize response field names (playId vs id) across create/read DTOs.
@@ -12,14 +13,17 @@ from app.utils.mappers import to_play_dto
 router = APIRouter(prefix="/v1/plays", tags=["plays"])
 
 @router.post("/", response_model=PlayCreateResponse, status_code=status.HTTP_201_CREATED)
-def create_play(payload: PlayCreateRequest, response: Response) -> PlayCreateResponse:
+def create_play(payload: PlayCreateRequest, 
+                response: Response, 
+                plays_repo: PlaysRepository=Depends(get_repo)) -> PlayCreateResponse:
     play = plays_repo.create_play(title=payload.title, video_path=payload.video_path)
 
     response.headers["Location"] = f'/v1/plays/{play.id}'
     return PlayCreateResponse(playId=uuid.UUID(play.id))
 
 @router.get("/{id}")
-def get_play(id: str):
+def get_play(id: str,
+             plays_repo: PlaysRepository=Depends(get_repo)):
     play = plays_repo.get_play(id)
     if not play:
         raise HTTPException(status_code=404, detail="Play not found")
@@ -30,7 +34,8 @@ def get_play(id: str):
 def list_plays(
     limit: Optional[int] = Query(None),
     cursor: Optional[str] = None, 
-    title: Optional[str] = None
+    title: Optional[str] = None,
+    plays_repo: PlaysRepository=Depends(get_repo)
 ):
     
     if limit is None:
@@ -51,7 +56,8 @@ def list_plays(
     return {"data": dtos, "nextCursor": next_cursor, "hasMore": hasMore}
 
 @router.delete("/{id}")
-def delete_play(id: str):
+def delete_play(id: str,
+                plays_repo: PlaysRepository=Depends(get_repo)):
     key = str(id)
     ok = plays_repo.delete_play(key)
     if not ok:

--- a/app/schemas/play.py
+++ b/app/schemas/play.py
@@ -32,12 +32,16 @@ class PlayCreateRequest(BaseModel):
     def validate_video_path(cls, v: str) -> str:
         v = v.strip()
         
-        # 1. Accept http(s) URLs
+        # 1. Acccept length ≤ 2048 chars
+        if len(v) > 2048:
+            raise ValueError("Video path must be ≤ 2048 chars")
+        
+        # 2. Accept http(s) URLs
         parsed = urlparse(v)
         if parsed.scheme in {"http", "https"} and parsed.netloc:
             return v
 
-        # 2) Accept file-like paths (Unix abs, Windows abs, or relative)
+        # 3. Accept file-like paths (Unix abs, Windows abs, or relative)
         if RE_UNIX_ABS.match(v) or RE_WIN_ABS.match(v) or RE_REL.match(v):
             return v
         

--- a/app/schemas/play.py
+++ b/app/schemas/play.py
@@ -2,7 +2,8 @@ from __future__ import annotations
 from pydantic import BaseModel, field_validator, StringConstraints
 from typing import Annotated
 from uuid import UUID
-from urllib.parse import urlparse
+from urllib.parse import urlparse, urlsplit
+from pathlib import Path
 import re
 
 # TECH_DEBT: TD4, TD9, TD12  — tighten video_path rules (https only, len≤2048, ext in set), per-field 422 arrays, case-insensitive ext check without mutating URL casing.
@@ -12,6 +13,7 @@ import re
 RE_UNIX_ABS = re.compile(r"^/[^*?\"<>|]+")
 RE_WIN_ABS  = re.compile(r"^[A-Za-z]:\\[^*?\"<>|]+")
 RE_REL      = re.compile(r"^\.(\.)?[/\\][^*?\"<>|]+")
+ALLOWED_EXTS = {".mp4", ".mov", ".m4v", ".webm"}
 
 class PlayCreateRequest(BaseModel):
     title: Annotated[str, StringConstraints(strip_whitespace=True, min_length=1, max_length=120)]
@@ -27,26 +29,28 @@ class PlayCreateRequest(BaseModel):
        
         return v
     
-    @field_validator("video_path")
+    @field_validator("video_path", mode="before")
     @classmethod
     def validate_video_path(cls, v: str) -> str:
-        v = v.strip()
+        if not isinstance(v, str):
+            raise ValueError("video_path must be a string")
         
+        v = v.strip()
         # 1. Acccept length ≤ 2048 chars
         if len(v) > 2048:
             raise ValueError("Video path must be ≤ 2048 chars")
-        
+                
         # 2. Accept http(s) URLs
-        parsed = urlparse(v)
-        if parsed.scheme in {"http", "https"} and parsed.netloc:
-            return v
-
-        # 3. Accept file-like paths (Unix abs, Windows abs, or relative)
-        if RE_UNIX_ABS.match(v) or RE_WIN_ABS.match(v) or RE_REL.match(v):
-            return v
+        parts = urlsplit(v)
+        if parts.scheme not in {"http", "https"} or not parts.netloc:
+            raise ValueError("video_path must be an http(s) url")
         
-        raise ValueError("video_path must be a http(s) URL or a valid file path")
+        # 3. Accept terminal extension (case-insensitive), queries/fragments are fine
+        suffix = Path(parts.path).suffix.lower()
+        if suffix not in ALLOWED_EXTS:
+            raise ValueError("video_path must be a supported format (.mp4, .mov, .mv4, .webm)")
 
+        return v
 class PlayCreateResponse(BaseModel):
     playId: UUID   
             

--- a/meta/plan.yml
+++ b/meta/plan.yml
@@ -33,7 +33,7 @@ days:
       - "List default/clamp tests (default=10; clamp to [1,100])"
       - "Optional hasMore boolean"
       - "docs: update README examples and error shapes"
-    tech_debt_resolve: []
+    tech_debt_resolve: [TD3, TD13]
     tech_debt_add: []
 
   - day: 11

--- a/meta/plan.yml
+++ b/meta/plan.yml
@@ -1,4 +1,4 @@
-current_day: 9
+current_day: 10
 
 days:
   - day: 8
@@ -32,7 +32,8 @@ days:
       - "POST /v1/plays video_path validation (https-only, allowed extensions, length)"
       - "List default/clamp tests (default=10; clamp to [1,100])"
       - "Optional hasMore boolean"
-    tech_debt_resolve: [TD2, TD15, TD18]
+      - "docs: update README examples and error shapes"
+    tech_debt_resolve: []
     tech_debt_add: []
 
   - day: 11

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,11 +3,35 @@ from fastapi.testclient import TestClient
 from app.main import app
 from app.repositories.plays_repo import clear_store
 from typing import Callable, List, Dict, Optional
+import uuid
 
 @pytest.fixture(scope="function")
 def client():
     # fresh client per test to avoid leaking in-memory state across tests
     return TestClient(app)
+
+@pytest.fixture(scope="function")
+def assert_201_field():
+    def _assert(res):
+        assert res.status_code == 201
+        data = res.json()
+        assert "playId" in data
+        
+        # Validate UUID-ish value (FastAPI serializes UUID -> string)
+        uuid_val = data["playId"]
+        uuid.UUID(uuid_val)
+    
+        assert "Location" in res.headers
+        # Location header
+        location = res.headers["Location"]
+        assert location.startswith("/v1/plays/")
+
+        # The id in Location should equal the JSON playId
+        loc_id = location.rsplit("/", 1)[-1]
+        assert loc_id == uuid_val
+        
+    return _assert
+
 
 @pytest.fixture
 def assert_422_field():

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,14 +1,22 @@
 import pytest
 from fastapi.testclient import TestClient
 from app.main import app
-from app.repositories.plays_repo import clear_store
+from app.repositories.memory import MemoryRepository
 from typing import Callable, List, Dict, Optional
 import uuid
+from app.deps import get_repo
 
 @pytest.fixture(scope="function")
 def client():
     # fresh client per test to avoid leaking in-memory state across tests
-    return TestClient(app)
+    repo = MemoryRepository()
+    
+    app.dependency_overrides[get_repo] = lambda: repo
+    
+    with TestClient(app) as c:
+        yield c
+    
+    app.dependency_overrides.clear()
 
 @pytest.fixture(scope="function")
 def assert_201_field():
@@ -57,7 +65,6 @@ def seed_many_plays(client) -> Callable[[List[Dict]], List[Dict]]:
     Returns the list of created Play DTOs (in the same order).
     """
     def _seed(stubs: List[Dict]) -> List[Dict]:
-        clear_store()
         created: List[Dict] = []
         for i, stub in enumerate(stubs, start=1):
             # Minimal valid payload 

--- a/tests/repositories/test_memory_repo.py
+++ b/tests/repositories/test_memory_repo.py
@@ -1,0 +1,64 @@
+import pytest
+from app.repositories.memory import MemoryRepository
+from app.repositories.plays_repo import PlaysRepository, _assert_protocol
+
+@pytest.fixture
+def repo():
+    r = MemoryRepository()
+    yield r
+    r.clear()
+    
+def _seed(repo: PlaysRepository, n, *, title_fmt="Alpha Cut {i:03d}"):
+    # helper to create n plays with zero-padded titles
+    ids: list[str] = []
+    for i in range(n):
+        title = title_fmt.format(i=i)
+        p = repo.create_play(title, "https://e.com/p.mp4")
+        ids.append(p.id)
+    return ids
+    
+def test_memory_repo_conforms():
+    _assert_protocol(MemoryRepository, PlaysRepository)
+        
+def test_create_and_get(repo):
+    p = repo.create_play("Spain PnR", "https://e.com/a.mp4")
+    got = repo.get_play(p.id)
+    assert got is not None
+    assert got.id == p.id
+    assert got.title == "Spain PnR"
+
+def test_get_unknown_returns_none(repo):
+    assert repo.get_play("does-not-exist") is None
+
+def test_delete_then_delete_again(repo):
+    p = repo.create_play("X", "https://e.com/a.mp4")
+    assert repo.delete_play(p.id) is True
+    assert repo.delete_play(p.id) is False
+
+def test_list_default_limit_10(repo):
+    _seed(repo, 13)
+    items, cur = repo.list_plays(cursor=None, limit=10, title_prefix=None)
+    assert len(items) == 10
+    assert cur == items[-1].id
+
+def test_list_cursor_paginates(repo):
+    _seed(repo, 12)
+    p1, c1 = repo.list_plays(limit=7, cursor=None, title_prefix=None)
+    p2, c2 = repo.list_plays(limit=7, cursor=c1, title_prefix=None)
+    assert len(p1) == 7
+    assert len(p2) == 5
+    assert c2 is None
+    assert set(x.id for x in p1).isdisjoint(set(x.id for x in p2))
+
+def test_list_title_prefix_filter_is_case_insensitive_and_trimmed(repo):
+    repo.create_play("Alpha", "https://e.com/a.mp4")
+    repo.create_play("alpha spain", "https://e.com/b.mp4")
+    repo.create_play("Beta", "https://e.com/c.mp4")
+    items, cur = repo.list_plays(limit=10, cursor=None, title_prefix="  AlPh  ")
+    assert [p.title for p in items] == ["Alpha", "alpha spain"]
+    assert cur is None
+
+def test_list_raises_value_error_for_invalid_cursor(repo):
+    _seed(repo, 3)
+    with pytest.raises(ValueError):
+        repo.list_plays(limit=2, cursor="not-in-store", title_prefix=None)

--- a/tests/routers/test_plays_list.py
+++ b/tests/routers/test_plays_list.py
@@ -200,3 +200,43 @@ def test_list_plays_clamps_limit_low_to_1(client, seed_many_plays):
     b2 = r2.json()
     assert len(b2["data"]) == 1
     assert b2["nextCursor"] is not None
+    
+def test_list_plays_has_more_returns_true_when_more_pages(client, seed_many_plays):
+    seed_many_plays({"title": f"Alpha Cut {i:03d}"} for i in range(15))
+    
+    r = client.get("/v1/plays?limit=10")
+    assert r.status_code == 200
+    
+    b = r.json()
+    assert len(b["data"]) == 10
+    assert b["nextCursor"] is not None 
+    assert b["hasMore"] is True
+    
+def test_list_plays_has_more_returns_false_when_on_last_page(client, seed_many_plays):
+    seed_many_plays({"title": f"Alpha Cut {i:03d}"} for i in range(15))
+    
+    r1 = client.get("/v1/plays?limit=10")
+    assert r1.status_code == 200
+    
+    b1 = r1.json()
+    assert len(b1["data"]) == 10
+    nextCursor =b1["nextCursor"]
+    
+    r2 = client.get(f"/v1/plays?limit=10&cursor={nextCursor}")
+    assert r2.status_code == 200
+    
+    b2 = r2.json()
+    assert len(b2["data"]) == 5
+    assert b2["nextCursor"] == None
+    assert b2["hasMore"] == False
+
+def test_list_has_more_respects_clamp_limit(client, seed_many_plays):
+    seed_many_plays({"title": f"Alpha Cut {i:03d}"} for i in range(120))
+    
+    r = client.get("/v1/plays?limit=9999") # clamps to 100
+    assert r.status_code == 200
+    
+    b = r.json()
+    assert len(b["data"]) == 100
+    assert b["nextCursor"] is not None 
+    assert b["hasMore"] is True

--- a/tests/routers/test_plays_list.py
+++ b/tests/routers/test_plays_list.py
@@ -1,3 +1,5 @@
+import pytest
+import uuid
 
 def test_list_plays_pagination_happy_path(client, seed_many_plays):
     # Arrange
@@ -139,3 +141,62 @@ def test_list_plays_sets_default_limit_of_10(client, seed_many_plays):
 
     last_id_on_page = b1["data"][-1]["id"]
     assert b1["nextCursor"] == last_id_on_page
+
+@pytest.mark.parametrize("limit", [0, -5])   
+def test_list_limit_below_min_is_clamped_to_1(client, seed_many_plays, limit):
+    seed_many_plays([{"title": f"Alpha Cut {i:02d}"} for i in range(5)])
+    
+    r = client.get(f"/v1/plays?limit={limit}")
+    assert r.status_code == 200
+    
+    b = r.json()
+    assert len(b["data"]) == 1
+    assert b["nextCursor"] is not None
+    
+def test_list_limit_above_max_is_clamped_to_100(client, seed_many_plays):
+    seed_many_plays([{"title": f"Alpha Cut {i:03d}"} for i in range(120)])
+
+    r = client.get("/v1/plays?limit=9999")
+    assert r.status_code == 200
+    b = r.json()
+    assert len(b["data"]) == 100
+    assert b["nextCursor"] is not None
+
+
+def test_list_plays_clamps_limit_high_to_100(client, seed_many_plays):
+    # Seed 120 so a clamped=100 first page leaves 20 for the next page
+    created = seed_many_plays([{"title": f"Alpha Cut {i}"} for i in range(120)])
+
+    r1 = client.get("/v1/plays?limit=1000")  # should clamp to 100
+    assert r1.status_code == 200
+    b1 = r1.json()
+    assert len(b1["data"]) == 100
+    # When more exist, we expect a continuation token
+    assert b1["nextCursor"] is not None
+
+    # Follow the cursor and ensure the remainder (20) is returned
+    cursor = b1["nextCursor"]
+    # sanity: looks like a uuid-ish id
+    uuid.UUID(cursor)
+    r2 = client.get(f"/v1/plays?cursor={cursor}&limit=1000")
+    assert r2.status_code == 200
+    b2 = r2.json()
+    assert len(b2["data"]) == 20
+    assert b2["nextCursor"] is None
+
+def test_list_plays_clamps_limit_low_to_1(client, seed_many_plays):
+    seed_many_plays([{"title": f"Alpha Cut {i}"} for i in range(5)])
+
+    # limit=0 → clamp up to 1
+    r1 = client.get("/v1/plays?limit=0")
+    assert r1.status_code == 200
+    b1 = r1.json()
+    assert len(b1["data"]) == 1
+    assert b1["nextCursor"] is not None  # more items remain
+
+    # negative also clamps to 1
+    r2 = client.get("/v1/plays?limit=-25")
+    assert r2.status_code == 200
+    b2 = r2.json()
+    assert len(b2["data"]) == 1
+    assert b2["nextCursor"] is not None

--- a/tests/routers/test_plays_list.py
+++ b/tests/routers/test_plays_list.py
@@ -35,7 +35,7 @@ def test_list_plays_pagination_happy_path(client, seed_many_plays):
     assert b3.get("nextCursor") in (None, )
     
 def test_list_plays_title_prefix_filter_happy_path(client, seed_many_plays):
-    _ = seed_many_plays([
+    seed_many_plays([
         {"title": "Alpha Cut"},
         {"title": "Alpha Spain"},
         {"title": "Bravo Ghost"},
@@ -126,3 +126,16 @@ def test_list_plays_bad_cursor_with_filter_returns_400(client, seed_many_plays):
     assert r.status_code == 400
     body = r.json()
     assert "detail" in body and "Invalid cursor" in body["detail"]
+
+def test_list_plays_sets_default_limit_of_10(client, seed_many_plays):
+    seed_many_plays([{f"title": "Alpha Cut {i:02d}"} for i in range(12)])
+    
+    r1 = client.get("/v1/plays")
+    assert r1.status_code == 200
+
+    b1 = r1.json()
+    assert len(b1["data"]) == 10
+    assert b1["nextCursor"] is not None
+
+    last_id_on_page = b1["data"][-1]["id"]
+    assert b1["nextCursor"] == last_id_on_page

--- a/tests/routers/test_plays_post.py
+++ b/tests/routers/test_plays_post.py
@@ -53,12 +53,18 @@ def test_create_play_422_missing_video_path(client, assert_422_field):
    
     assert_422_field(res, "video_path")
 
-def test_create_play_422_ftp_scheme_rejected(client, assert_422_field):
-    """video_path uses ftp:// → 422.video_path"""
-    payload = {"title": "Valid", "video_path": "ftp://server/clip.mp4"}
-    res = client.post("/v1/plays", json=payload)
+def test_create_play_rejects_non_http_or_https_schemes(client, assert_422_field):
+    """video_path uses non http(s) → 422.video_path"""
+    bad_urls = [
+        "ftp://example.com/clip.mp4",
+        "file:///tmp/clip.mp4",
+        "gs://bucket/clip.mp4"
+    ]
     
-    assert_422_field(res, "video_path")
+    for bad_url in bad_urls:
+        res = client.post("/v1/plays", json= {"title": "Valid", "video_path": bad_url })
+        assert_422_field(res, "video_path")
+    
 
 @pytest.mark.skip(reason="planned Day 12: invalid types on upload")
 def test_create_play_422_unsupported_extension_avi(): ...

--- a/tests/routers/test_plays_post.py
+++ b/tests/routers/test_plays_post.py
@@ -3,7 +3,7 @@ import uuid
 
 # TECH_DEBT: TD9 — assert per-field 422 arrays for all validation failures.
 
-def test_create_play_ok_https_mp4_returns_201_and_location_header(client):
+def test_create_play_ok_https_mp4_returns_201_and_location_header(client, assert_201_field):
     """
     Happy path:
       - title: non-empty
@@ -15,22 +15,8 @@ def test_create_play_ok_https_mp4_returns_201_and_location_header(client):
     payload = {"title": "Drop vs. Spain PnR", "video_path":"https://example.com/clip.mp4"}
     res = client.post("/v1/plays", json=payload)
     
-    assert res.status_code == 201
+    assert_201_field(res)
     
-    data = res.json()
-    assert "playId" in data
-    # Validate UUID-ish value (FastAPI serializes UUID -> string)
-    uuid_val = data["playId"]
-    uuid.UUID(uuid_val)
-    
-    # Location header
-    assert "Location" in res.headers
-    location = res.headers["Location"]
-    assert location.startswith("/v1/plays/")
-
-    # The id in Location should equal the JSON playId
-    loc_id = location.rsplit("/", 1)[-1]
-    assert loc_id == uuid_val
 
 def test_create_play_422_empty_title(client, assert_422_field):
     """Empty/whitespace-only title → 422.title"""
@@ -64,8 +50,27 @@ def test_create_play_rejects_non_http_or_https_schemes(client, assert_422_field)
     for bad_url in bad_urls:
         res = client.post("/v1/plays", json= {"title": "Valid", "video_path": bad_url })
         assert_422_field(res, "video_path")
-    
 
+def test_create_play_422_rejects_video_path_over_2048_chars(client, assert_422_field):
+    prefix = "https://example.com/"
+    ext = ".mp4"
+    n = 2049 - (len(prefix) + len(ext))
+    url = prefix + ("a" * n) + ext
+    
+    res = client.post("/v1/plays", json= {"title": "Valid", "video_path": url })
+    
+    assert_422_field(res, "video_path")   
+
+def test_create_play_201_allows_video_path_at_2048_chars(client, assert_201_field):
+    prefix = "https://example.com/"
+    ext = ".mp4"
+    n = 2048 - (len(prefix) + len(ext))
+    url = prefix + ("a" * n) + ext
+    
+    res = client.post("/v1/plays", json= {"title": "Valid", "video_path": url })
+    
+    assert_201_field(res)
+    
 @pytest.mark.skip(reason="planned Day 12: invalid types on upload")
 def test_create_play_422_unsupported_extension_avi(): ...
 

--- a/tests/routers/test_plays_post.py
+++ b/tests/routers/test_plays_post.py
@@ -70,10 +70,28 @@ def test_create_play_201_allows_video_path_at_2048_chars(client, assert_201_fiel
     res = client.post("/v1/plays", json= {"title": "Valid", "video_path": url })
     
     assert_201_field(res)
-    
-@pytest.mark.skip(reason="planned Day 12: invalid types on upload")
-def test_create_play_422_unsupported_extension_avi(): ...
 
+@pytest.mark.parametrize("url", [
+     "https://e.com/clip.avi",
+    "https://e.com/clip.mkv",
+    "https://e.com/clip",
+    "https://e.com/clip.mp4.",
+    "https://e.com/clip.mp4/extra",
+])
+def test_create_play_422_rejects_unsupported_extensions(client, assert_422_field, url):
+    res = client.post("/v1/plays", json={"title": "Valid", "video_path": url})
+    assert_422_field(res, "video_path")
+
+@pytest.mark.parametrize("url", [
+    "https://e.com/c.MP4",
+    "https://e.com/c.mov?x=1#y",
+    "https://e.com/c.m4V",
+    "https://e.com/c.WeBm?token=abc",
+])
+def test_create_play_201_allows_supported_extensions_case_insensitive(client, assert_201_field, url):
+    res = client.post("/v1/plays", json={"title": "Valid", "video_path": url})
+    assert_201_field(res)
+    
 @pytest.mark.skip(reason="planned Day 11: local paths gated by ALLOW_LOCAL_VIDEO_PATHS=false")
 def test_create_play_422_local_file_path_rejected_when_override_off(): ...
 


### PR DESCRIPTION
### Day & Branch
- **Day:** 10
- **Branch:** feat/api-validation-and-list-polish

### Scope
- **Objective (from meta/plan.yml):** Validation polish + list clamps
- **Deliverables checked:**
  - [ ] POST /v1/plays video_path validation (https-only, allowed extensions, length)
  - [ ] List default/clamp tests (default=10; clamp to [1,100])
  - [ ] Optional hasMore boolean
  - [ ] docs: update README examples and error shapes

### Tech Debt
- **Resolves TD:** TD3, TD13
- **Adds TD:** <none>

### Validation (run locally before opening PR)
- [ ] `python tools/validate_structure.py` passed
- [ ] `python tools/validate_plan.py` passed
- [ ] `pytest -q` passed
- [ ] Docs updated where needed (README / ROADMAP / TECH_DEBT)

### Notes / Screenshots (optional)
<!-- Add any context, screenshots, or follow-ups here -->
